### PR TITLE
Add 'extended: true' option to bodyParser.urlencoded()

### DIFF
--- a/server.js
+++ b/server.js
@@ -7,7 +7,9 @@ var cors = require('cors');
 app.use(express.static(__dirname + '/public'));
 
 // So we can POST.
-app.use(bodyParser.urlencoded());
+app.use(bodyParser.urlencoded({
+  extended: true
+}));
 
 // Since Mixmax calls this API directly from the client-side, it must be whitelisted.
 var corsOptions = {


### PR DESCRIPTION
I kept getting error on my Ubuntu 16.04 that "body-parser deprecated undefined extended: provide extended option server.js:10:20"
Adding extended option explicitly will remove this error message!
